### PR TITLE
Provide absolute URL to fix routing issues

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
@@ -71,14 +71,14 @@ jobs:
 
       # Add vendor folder in cache to make next builds faster
       - name: Cache vendor folder
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
 
       # Add composer local folder in cache to make next builds faster
       - name: Cache composer folder
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache
           key: php-composer-cache

--- a/statscatalog.php
+++ b/statscatalog.php
@@ -148,7 +148,6 @@ class statscatalog extends Module
     public function hookDisplayAdminStatsModules($params)
     {
         $categories = Category::getCategories($this->context->language->id, true, false);
-        $product_token = Tools::getAdminToken('AdminProducts' . (int) Tab::getIdFromClassName('AdminProducts') . (int) $this->context->employee->id);
         $irow = 0;
 
         if ($id_category = (int) Tools::getValue('id_category')) {
@@ -239,7 +238,7 @@ class statscatalog extends Module
 						<td>' . $product['name'] . '</td>
 						<td class="left">
 							<div class="btn-group btn-group-action">
-								<a class="btn btn-default" href="' . Tools::safeOutput('index.php?controller=AdminProducts&id_product=' . $product['id_product'] . '&addproduct&token=' . $product_token) . '" target="_blank">
+								<a class="btn btn-default" href="' . Tools::safeOutput($this->context->link->getAdminLink('AdminProducts', true) . '&id_product=' . $product['id_product'] . '&addproduct') . '" target="_blank">
 									<i class="icon-edit"></i> ' . $this->trans('Edit', [], 'Admin.Global') . '
 								</a>
 								<button data-toggle="dropdown" class="btn btn-default dropdown-toggle" type="button">


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Provide absolute URL to fix routing issues. Fixes potential issues coming from relative URLs not being reliable after symfony migration. See https://github.com/PrestaShop/PrestaShop/issues/39185. cc @Touxten 
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/39185
| Sponsor company   | TRENDO s.r.o.
| How to test?      | Just test the module can be configured correctly and loads in the backoffice, so we didn't break anything or have some typo. (On nginx server, this could be problematic.)
