### PR TITLE
Update statscatalog.php

### DIFF
--- a/statscatalog.php
+++ b/statscatalog.php
@@ -157,7 +157,7 @@ class statscatalog extends Module
 
         $result1 = $this->getQuery1();
         $total = $result1['total'];
-        $average_price = $result1['average_price'];
+        $average_price = (float) $result1['average_price'];
         $total_pictures = $result1['images'];
         $average_pictures = $total ? $total_pictures / $total : 0;
 


### PR DESCRIPTION
Fix the $average_price issue that is not float.
Solve Bug #43

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When you just install Prestashop and you enable the module statscatalog v2.0.5 when you access the stats from Stats menu you will get an error 500.
| Type?         | bug fix / critical
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes [PrestaShop/Prestashop#43.](https://github.com/PrestaShop/statscatalog/issues/43)
| How to test?  | Install prestashop 9.0.x, Enable the module: statscatalog v2.0.5, visit: Stats > Catalog statistics, see the error 500

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
