### PR TITLE
Update statscatalog.php

### DIFF
--- a/statscatalog.php
+++ b/statscatalog.php
@@ -156,9 +156,9 @@ class statscatalog extends Module
         }
 
         $result1 = $this->getQuery1();
-        $total = $result1['total'];
-        $average_price = $result1['average_price'];
-        $total_pictures = $result1['images'];
+        $total = (int) $result1['total'];
+        $average_price = (float) $result1['average_price'];
+        $total_pictures = (int) $result1['images'];
         $average_pictures = $total ? $total_pictures / $total : 0;
 
         $never_bought = $this->getProductsNB($this->context->language->id);


### PR DESCRIPTION
Fix error of price format

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | the statscatalog module have a bug on fresh installation go to the statisticv menu "Catalog Stats" and we get this an error: PrestaShop\PrestaShop\Core\Localization\Locale::formatPrice(): Argument #1 ($number) must be of type string/int/float, null given, called in /home/ffpurify/public_html/modules/statscatalog/statscatalog.php on line 205

| Type?         | bug fix 
| BC breaks?    |no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | On fresh ps 9.x installation go to "statscatalog" stats and see the error:

PrestaShop\PrestaShop\Core\Localization\Locale::formatPrice(): Argument #1 ($number) must be of type string|int|float, null given, called in /home/ffpurify/public_html/modules/statscatalog/statscatalog.php on line 205


